### PR TITLE
feat: 會員管理

### DIFF
--- a/TeaTime.DataAccess/Migrations/20251207135051_UpdateNameToBeStringApplicationUser.Designer.cs
+++ b/TeaTime.DataAccess/Migrations/20251207135051_UpdateNameToBeStringApplicationUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TeaTime.DataAccess.Data;
 
@@ -11,9 +12,11 @@ using TeaTime.DataAccess.Data;
 namespace TeaTime.DataAccess.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251207135051_UpdateNameToBeStringApplicationUser")]
+    partial class UpdateNameToBeStringApplicationUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TeaTime.DataAccess/Migrations/20251207135051_UpdateNameToBeStringApplicationUser.cs
+++ b/TeaTime.DataAccess/Migrations/20251207135051_UpdateNameToBeStringApplicationUser.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeaTime.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateNameToBeStringApplicationUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "AspNetUserTokens",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserTokens",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderKey",
+                table: "AspNetUserLogins",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserLogins",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "AspNetUserTokens",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserTokens",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Name",
+                table: "AspNetUsers",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ProviderKey",
+                table: "AspNetUserLogins",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LoginProvider",
+                table: "AspNetUserLogins",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+        }
+    }
+}

--- a/TeaTime.Models/ApplicationUser.cs
+++ b/TeaTime.Models/ApplicationUser.cs
@@ -6,7 +6,7 @@ namespace TeaTime.Models
     public class ApplicationUser : IdentityUser
     {
         [Required]
-        public int Name { get; set; }
+        public string Name { get; set; }
 
         public string Address { get; set; }
     }

--- a/TeaTime.Utility/EmailSender.cs
+++ b/TeaTime.Utility/EmailSender.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Identity.UI.Services;
+
+namespace TeaTime.Utility
+{
+    public class EmailSender : IEmailSender
+    {
+        public Task SendEmailAsync(string email, string subject, string htmlMessage)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/TeaTime.Utility/SD.cs
+++ b/TeaTime.Utility/SD.cs
@@ -2,5 +2,24 @@
 {
     public static class SD
     {
+        /// <summary>
+        /// 系統管理者角色
+        /// </summary>
+        public const string Role_Admin = "Admin";
+
+        /// <summary>
+        /// 顧客角色
+        /// </summary>
+        public const string Role_Customer = "Customer";
+
+        /// <summary>
+        /// 員工角色
+        /// </summary>
+        public const string Role_Employee = "Employee";
+
+        /// <summary>
+        /// 經理人角色
+        /// </summary>
+        public const string Role_Manager = "Manager";
     }
 }

--- a/TeaTime.Utility/TeaTime.Utility.csproj
+++ b/TeaTime.Utility/TeaTime.Utility.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.11" />
+  </ItemGroup>
+
 </Project>

--- a/TeaTimeApplication/Areas/Admin/Controllers/CategoryController.cs
+++ b/TeaTimeApplication/Areas/Admin/Controllers/CategoryController.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using TeaTime.DataAccess.UnitOfWork;
 using TeaTime.Models;
+using TeaTime.Utility;
 
 namespace TeaTimeApplication.Areas.Admin.Controllers
 {
@@ -8,6 +10,7 @@ namespace TeaTimeApplication.Areas.Admin.Controllers
     /// 類別 Controller
     /// </summary>
     [Area("Admin")]
+    [Authorize(Roles = SD.Role_Admin)]
     public class CategoryController : Controller
     {
         /// <summary>

--- a/TeaTimeApplication/Areas/Admin/Controllers/ProductController.cs
+++ b/TeaTimeApplication/Areas/Admin/Controllers/ProductController.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using TeaTime.DataAccess.UnitOfWork;
 using TeaTime.Models;
 using TeaTime.Models.ViewModels;
+using TeaTime.Utility;
 
 namespace TeaTimeApplication.Areas.Admin.Controllers
 {
@@ -10,6 +12,7 @@ namespace TeaTimeApplication.Areas.Admin.Controllers
     /// 產品 Controller
     /// </summary>
     [Area("Admin")]
+    [Authorize(Roles = SD.Role_Admin)]
     public class ProductController : Controller
     {
         /// <summary>

--- a/TeaTimeApplication/Areas/Admin/Views/_ViewImports.cshtml
+++ b/TeaTimeApplication/Areas/Admin/Views/_ViewImports.cshtml
@@ -1,5 +1,6 @@
 ﻿@using TeaTimeApplication
 @using TeaTime.Models
+@using TeaTime.Utility
 
 <!-- 引用 ViewModels-->
 @using TeaTime.Models.ViewModels

--- a/TeaTimeApplication/Areas/Customer/Views/_ViewImports.cshtml
+++ b/TeaTimeApplication/Areas/Customer/Views/_ViewImports.cshtml
@@ -1,5 +1,6 @@
 ﻿@using TeaTimeApplication
 @using TeaTime.Models
+@using TeaTime.Utility
 
 <!-- 引用 ViewModels-->
 @using TeaTime.Models.ViewModels

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Manage/_Layout.cshtml
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Manage/_Layout.cshtml
@@ -5,7 +5,7 @@
     }
     else
     {
-        Layout = "/Areas/Identity/Pages/_Layout.cshtml";
+        Layout = "/Views/Shared/_Layout.cshtml";
     }
 }
 

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Manage/_ViewStart.cshtml
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Manage/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout.cshtml";
+}

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml
@@ -27,6 +27,12 @@
                 <label asp-for="Input.ConfirmPassword">Confirm Password</label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>
+            @*角色列表選單*@
+            <div class="form-floating mb-3">
+                <select asp-for="Input.Role" asp-items="@Model.Input.RoleList" class="form-select">
+                    <option disabled selected>-Select Role-</option>
+                </select>
+            </div>
             <button id="registerSubmit" type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
         </form>
     </div>

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml
@@ -18,6 +18,16 @@
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
             <div class="form-floating mb-3">
+                <input asp-for="Input.Name" class="form-control" placeholder="username" />
+                <label asp-for="Input.Name">Name</label>
+                <span asp-validation-for="Input.Name" class="text-danger"></span>
+            </div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.PhoneNumber" class="form-control" placeholder="phoneNumber" />
+                <label asp-for="Input.PhoneNumber">PhoneNumber</label>
+                <span asp-validation-for="Input.PhoneNumber" class="text-danger"></span>
+            </div>
+            <div class="form-floating mb-3">
                 <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
                 <label asp-for="Input.Password">Password</label>
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
@@ -26,6 +36,11 @@
                 <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
                 <label asp-for="Input.ConfirmPassword">Confirm Password</label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+            </div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.Address" class="form-control" placeholder="address" />
+                <label asp-for="Input.Address">Address</label>
+                <span asp-validation-for="Input.Address" class="text-danger"></span>
             </div>
             @*角色列表選單*@
             <div class="form-floating mb-3">

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -152,6 +152,16 @@ namespace TeaTimeApplication.Areas.Identity.Pages.Account
                 {
                     _logger.LogInformation("User created a new account with password.");
 
+                    // 分配 user 的角色
+                    if (!String.IsNullOrEmpty(Input.Role))
+                    {
+                        await _userManager.AddToRoleAsync(user, Input.Role);
+                    }
+                    else
+                    {
+                        await _userManager.AddToRoleAsync(user, SD.Role_Customer);
+                    }
+
                     var userId = await _userManager.GetUserIdAsync(user);
                     var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                     code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -19,12 +19,14 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using TeaTime.Models;
+using TeaTime.Utility;
 
 namespace TeaTimeApplication.Areas.Identity.Pages.Account
 {
     public class RegisterModel : PageModel
     {
         private readonly SignInManager<IdentityUser> _signInManager;
+        private readonly RoleManager<IdentityRole> _roleManager;
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IUserStore<IdentityUser> _userStore;
         private readonly IUserEmailStore<IdentityUser> _emailStore;
@@ -33,12 +35,14 @@ namespace TeaTimeApplication.Areas.Identity.Pages.Account
 
         public RegisterModel(
             UserManager<IdentityUser> userManager,
+            RoleManager<IdentityRole> roleManager,
             IUserStore<IdentityUser> userStore,
             SignInManager<IdentityUser> signInManager,
             ILogger<RegisterModel> logger,
             IEmailSender emailSender)
         {
             _userManager = userManager;
+            _roleManager = roleManager;
             _userStore = userStore;
             _emailStore = GetEmailStore();
             _signInManager = signInManager;
@@ -103,6 +107,16 @@ namespace TeaTimeApplication.Areas.Identity.Pages.Account
 
         public async Task OnGetAsync(string returnUrl = null)
         {
+            // 讓程式去檢查 SD 是否已經有 Customer 的角色，如果有就不需要再建立一次，沒有的話就建新的角色
+            if (!_roleManager.RoleExistsAsync(SD.Role_Customer).GetAwaiter().GetResult())
+            {
+                _roleManager.CreateAsync(new IdentityRole(SD.Role_Admin)).GetAwaiter().GetResult();
+                _roleManager.CreateAsync(new IdentityRole(SD.Role_Customer)).GetAwaiter().GetResult();
+                _roleManager.CreateAsync(new IdentityRole(SD.Role_Employee)).GetAwaiter().GetResult();
+                _roleManager.CreateAsync(new IdentityRole(SD.Role_Manager)).GetAwaiter().GetResult();
+            }
+
+
             ReturnUrl = returnUrl;
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
         }

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -93,12 +93,18 @@ namespace TeaTimeApplication.Areas.Identity.Pages.Account
             /// 角色
             /// </summary>
             public string? Role { get; set; }
-            
+
             /// <summary>
             /// 角色列表
             /// </summary>
             [ValidateNever]
             public IEnumerable<SelectListItem> RoleList { get; set; }
+
+            public string Name { get; set; }
+
+            public string? Address { get; set; }
+
+            public string? PhoneNumber { get; set; }
 
             /// <summary>
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
@@ -109,7 +115,6 @@ namespace TeaTimeApplication.Areas.Identity.Pages.Account
             [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
             public string ConfirmPassword { get; set; }
         }
-
 
         public async Task OnGetAsync(string returnUrl = null)
         {
@@ -146,6 +151,9 @@ namespace TeaTimeApplication.Areas.Identity.Pages.Account
 
                 await _userStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
                 await _emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+                user.Name = Input.Name;
+                user.Address = Input.Address;
+                user.PhoneNumber = Input.PhoneNumber;
                 var result = await _userManager.CreateAsync(user, Input.Password);
 
                 if (result.Succeeded)

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -2,22 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Logging;
 using TeaTime.Models;
 using TeaTime.Utility;
 
@@ -95,6 +90,17 @@ namespace TeaTimeApplication.Areas.Identity.Pages.Account
             public string Password { get; set; }
 
             /// <summary>
+            /// 角色
+            /// </summary>
+            public string? Role { get; set; }
+            
+            /// <summary>
+            /// 角色列表
+            /// </summary>
+            [ValidateNever]
+            public IEnumerable<SelectListItem> RoleList { get; set; }
+
+            /// <summary>
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
@@ -116,6 +122,15 @@ namespace TeaTimeApplication.Areas.Identity.Pages.Account
                 _roleManager.CreateAsync(new IdentityRole(SD.Role_Manager)).GetAwaiter().GetResult();
             }
 
+            // 將角色列表帶到前端頁面
+            Input = new InputModel()
+            {
+                RoleList = _roleManager.Roles.Select(r => r.Name).Select(i => new SelectListItem
+                {
+                    Text = i,
+                    Value = i
+                })
+            };
 
             ReturnUrl = returnUrl;
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();

--- a/TeaTimeApplication/Areas/Identity/Pages/_ViewImports.cshtml
+++ b/TeaTimeApplication/Areas/Identity/Pages/_ViewImports.cshtml
@@ -1,4 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Identity
 @using TeaTimeApplication.Areas.Identity
 @using TeaTimeApplication.Areas.Identity.Pages
+@using TeaTime.Utility
+@using TeaTime.Models
+@using TeaTime.Models.ViewModels
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/TeaTimeApplication/Program.cs
+++ b/TeaTimeApplication/Program.cs
@@ -2,6 +2,8 @@ using Microsoft.EntityFrameworkCore;
 using TeaTime.DataAccess.Data;
 using TeaTime.DataAccess.UnitOfWork;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using TeaTime.Utility;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,7 +15,9 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 
-builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true).AddEntityFrameworkStores<ApplicationDbContext>();
+// 註冊 Identity 服務
+builder.Services.AddIdentity<IdentityUser, IdentityRole>(options => options.SignIn.RequireConfirmedAccount = true)
+                .AddEntityFrameworkStores<ApplicationDbContext>();
 
 // 註冊使用 Razor 服務
 builder.Services.AddRazorPages();
@@ -25,6 +29,9 @@ if (builder.Environment.IsDevelopment())
 }
 // 註冊 IUnitOfWork,UnitOfWork DI 服務
 builder.Services.AddScoped<IUnitOfWork,UnitOfWork>();
+
+// 註冊 EmailSender 服務
+builder.Services.AddScoped<IEmailSender, EmailSender>();
 
 var app = builder.Build();
 

--- a/TeaTimeApplication/Program.cs
+++ b/TeaTimeApplication/Program.cs
@@ -17,7 +17,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 
 // 註冊 Identity 服務
 builder.Services.AddIdentity<IdentityUser, IdentityRole>(options => options.SignIn.RequireConfirmedAccount = true)
-                .AddEntityFrameworkStores<ApplicationDbContext>();
+                .AddEntityFrameworkStores<ApplicationDbContext>().AddDefaultTokenProviders();
 
 // 註冊使用 Razor 服務
 builder.Services.AddRazorPages();

--- a/TeaTimeApplication/Program.cs
+++ b/TeaTimeApplication/Program.cs
@@ -19,6 +19,14 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 builder.Services.AddIdentity<IdentityUser, IdentityRole>(options => options.SignIn.RequireConfirmedAccount = true)
                 .AddEntityFrameworkStores<ApplicationDbContext>().AddDefaultTokenProviders();
 
+// 註冊 Cookie 設定
+builder.Services.ConfigureApplicationCookie(options =>
+{
+    options.LoginPath = $"/Identity/Account/Login";
+    options.LogoutPath = $"/Identity/Account/Logout";
+    options.AccessDeniedPath = $"/Identity/Account/AccessDenied";
+});
+
 // 註冊使用 Razor 服務
 builder.Services.AddRazorPages();
 

--- a/TeaTimeApplication/TeaTimeApplication.csproj
+++ b/TeaTimeApplication/TeaTimeApplication.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TeaTime.DataAccess\TeaTime.DataAccess.csproj" />
+    <ProjectReference Include="..\TeaTime.Utility\TeaTime.Utility.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TeaTimeApplication/Views/Shared/_Layout.cshtml
+++ b/TeaTimeApplication/Views/Shared/_Layout.cshtml
@@ -31,20 +31,25 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="Customer" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
-                        <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle text-dark" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" area-expanded="false">
-                                內容管理
-                            </a>
-                            <div class="dropdown-menu">
-                                <a class="dropdown-item" asp-area="Admin" asp-controller="Category" asp-action="Index">
-                                    類別
+
+                        @*新增判斷登入角色為 admin 才會看到 [內容管理]*@
+                        @if (User.IsInRole(SD.Role_Admin))
+                        {
+                            <li class="nav-item dropdown">
+                                <a class="nav-link dropdown-toggle text-dark" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" area-expanded="false">
+                                    內容管理
                                 </a>
-                                <a class="dropdown-item" asp-area="Admin" asp-controller="Product" asp-action="Index">
-                                    產品
-                                </a>
-                                <div class="dropdown-divider"></div>
-                            </div>
-                        </li>
+                                <div class="dropdown-menu">
+                                    <a class="dropdown-item" asp-area="Admin" asp-controller="Category" asp-action="Index">
+                                        類別
+                                    </a>
+                                    <a class="dropdown-item" asp-area="Admin" asp-controller="Product" asp-action="Index">
+                                        產品
+                                    </a>
+                                    <div class="dropdown-divider"></div>
+                                </div>
+                            </li>
+                        }
                     </ul>
                     <partial name="_LoginPartial" />
                 </div>

--- a/TeaTimeApplication/Views/_ViewImports.cshtml
+++ b/TeaTimeApplication/Views/_ViewImports.cshtml
@@ -1,5 +1,6 @@
 ﻿@using TeaTimeApplication
 @using TeaTime.Models
+@using TeaTime.Utility
 
 <!-- 引用 ViewModels-->
 @using TeaTime.Models.ViewModels


### PR DESCRIPTION
## Summary

此 PR 調整 Identity 註冊與角色管理流程，讓註冊頁面可以輸入使用者姓名、電話、地址並選擇角色。

系統啟動與註冊相關流程改為支援 IdentityRole，並新增 Admin/Customer/Employee/Manager 角色常數與註冊時的角色指派邏輯。

後台類別與產品管理頁面新增 Admin 角色授權限制，導覽列也改為只有 Admin 可看到內容管理選單。另包含 ApplicationUser.Name 欄位型別由 int 改為 string 的 EF Core migration。

## Changes

- 新增 EmailSender 實作，提供 IEmailSender 註冊使用。
- 新增角色常數：Admin、Customer、Employee、Manager。
- 新增 EF Core migration，將 AspNetUsers.Name 從 int 調整為 nvarchar(max)，並同步更新 Identity token/login 相關欄位長度。
- 修改 ApplicationUser.Name 型別為 string，並在註冊流程寫入 Name、Address、PhoneNumber。
- 修改 Identity 註冊頁面，新增 Name、PhoneNumber、Address 與 Role 下拉選單。
- 修改註冊頁面後端，初始化角色資料、載入角色清單，並在建立使用者後指派選擇的角色；未選擇角色時預設指派 Customer。
- 修改 Identity 註冊設定，從 AddDefaultIdentity 改為 AddIdentity<IdentityUser, IdentityRole> 並加入 token provider 與 cookie 路徑設定。
- 修改 Admin 區域 Category/Product controller，限制只有 Admin 角色可存取。
- 修改共用 Layout，只有 Admin 角色可看到內容管理選單。
- 調整多個 _ViewImports.cshtml，加入 TeaTime.Utility 等命名空間引用。
- 調整 Identity Manage 頁面的 layout 指向共用 layout，並新增 _ViewStart.cshtml。