### PR TITLE
fix(layout): 移除一般導覽列的類別入口

### DIFF
--- a/TeaTimeApplication/Views/Shared/_Layout.cshtml
+++ b/TeaTimeApplication/Views/Shared/_Layout.cshtml
@@ -26,9 +26,6 @@
                             <a class="nav-link text-dark" asp-area="Customer" asp-controller="Home" asp-action="Index">首頁</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Category" asp-action="Index">類別</a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="Customer" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
 


### PR DESCRIPTION
## Summary

此 PR 移除首頁一般導覽列中的「類別」入口，避免非管理者使用者看到不應直接進入的管理功能連結。

類別管理功能仍保留在管理者可見的內容管理區域中，導覽列對一般使用者會更符合實際權限設計。

## Changes

- 移除了共用版面 _Layout.cshtml 中固定顯示的「類別」導覽連結
- 保留首頁、Privacy、購物車與管理者內容管理選單的既有導覽行為
- 尚未從目前上下文確認是否有新增自動化測試或手動驗證紀錄