### PR TITLE
Feat: 專案部署

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ ehthumbs.db
 
 # .net core appsettings
 secrets.json
+TeaTimeApplication/appsettings.Production.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/TeaTime.DataAccess/DBInitializer/DbInitializer.cs
+++ b/TeaTime.DataAccess/DBInitializer/DbInitializer.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using TeaTime.DataAccess.Data;
+using TeaTime.Models;
+using TeaTime.Utility;
+
+namespace TeaTime.DataAccess.DBInitializer
+{
+    /// <summary>
+    /// 負責在應用程式啟動時初始化資料庫與身分角色資料。
+    /// </summary>
+    public class DbInitializer : IDbInitializer
+    {
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly RoleManager<IdentityRole> _roleManager;
+        private readonly ApplicationDbContext _db;
+
+        /// <summary>
+        /// 初始化資料庫初始化器所需的使用者管理、角色管理與資料庫內容服務。
+        /// </summary>
+        /// <param name="userManager">用於建立預設管理者帳號與指派角色的使用者管理服務。</param>
+        /// <param name="roleManager">用於檢查與建立系統角色的角色管理服務。</param>
+        /// <param name="db">用於執行資料庫遷移與查詢預設管理者帳號的資料庫內容。</param>
+        public DbInitializer(UserManager<IdentityUser> userManager,
+                             RoleManager<IdentityRole> roleManager,
+                             ApplicationDbContext db) 
+        {
+            _userManager = userManager;
+            _roleManager = roleManager;
+            _db = db;
+        }
+
+        /// <summary>
+        /// 執行資料庫初始化流程，包含套用待處理的 migration、建立預設角色與預設管理者帳號。
+        /// </summary>
+        public void Initialize() 
+        {
+            try 
+            {
+                // 檢查是否有待處理的 migration，如果有就進行資料庫遷移 migration
+                if (_db.Database.GetPendingMigrations().Count() > 0) 
+                {
+                    _db.Database.Migrate();
+                }
+            }
+            catch (Exception ex) { }
+            // 檢查角色是否存在，如果不存在就建立所有角色以及我們的管理者帳號
+            if (!_roleManager.RoleExistsAsync(SD.Role_Customer).GetAwaiter().GetResult()) 
+            {
+                _roleManager.CreateAsync(new IdentityRole(SD.Role_Customer)).GetAwaiter().GetResult();
+                _roleManager.CreateAsync(new IdentityRole(SD.Role_Manager)).GetAwaiter().GetResult();
+                _roleManager.CreateAsync(new IdentityRole(SD.Role_Employee)).GetAwaiter().GetResult();
+                _roleManager.CreateAsync(new IdentityRole(SD.Role_Admin)).GetAwaiter().GetResult();
+
+                _userManager.CreateAsync(new ApplicationUser
+                {
+                    UserName = "admin@gmail.com",
+                    Email = "admin@gmail.com",
+                    Name = "Administrator",
+                    PhoneNumber = "0911111111",
+                    Address = "test address 123",
+                    EmailConfirmed = true
+                }, "Admin123*").GetAwaiter().GetResult();
+
+                ApplicationUser user = _db.ApplicationUsers.FirstOrDefault(u => u.Email == "admin@gmail.com");
+                _userManager.AddToRoleAsync(user, SD.Role_Admin).GetAwaiter().GetResult();
+            }
+
+            return;
+        }
+
+    }
+}

--- a/TeaTime.DataAccess/DBInitializer/IDbInitializer.cs
+++ b/TeaTime.DataAccess/DBInitializer/IDbInitializer.cs
@@ -1,0 +1,13 @@
+﻿namespace TeaTime.DataAccess.DBInitializer
+{
+    /// <summary>
+    /// 定義應用程式啟動時需要執行的資料庫初始化流程。
+    /// </summary>
+    public interface IDbInitializer
+    {
+        /// <summary>
+        /// 執行資料庫遷移、角色建立與預設管理者帳號建立流程。
+        /// </summary>
+        void Initialize();
+    }
+}

--- a/TeaTime.DataAccess/TeaTime.DataAccess.csproj
+++ b/TeaTime.DataAccess/TeaTime.DataAccess.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TeaTime.Models\TeaTime.Models.csproj" />
+    <ProjectReference Include="..\TeaTime.Utility\TeaTime.Utility.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TeaTimeApplication/Areas/Admin/Controllers/CategoryController.cs
+++ b/TeaTimeApplication/Areas/Admin/Controllers/CategoryController.cs
@@ -10,7 +10,7 @@ namespace TeaTimeApplication.Areas.Admin.Controllers
     /// 類別 Controller
     /// </summary>
     [Area("Admin")]
-    [Authorize(Roles = SD.Role_Admin)]
+    [Authorize(Roles = SD.Role_Admin + "," + SD.Role_Manager)]
     public class CategoryController : Controller
     {
         /// <summary>

--- a/TeaTimeApplication/Areas/Admin/Controllers/ProductController.cs
+++ b/TeaTimeApplication/Areas/Admin/Controllers/ProductController.cs
@@ -12,7 +12,7 @@ namespace TeaTimeApplication.Areas.Admin.Controllers
     /// 產品 Controller
     /// </summary>
     [Area("Admin")]
-    [Authorize(Roles = SD.Role_Admin)]
+    [Authorize(Roles = SD.Role_Admin + "," + SD.Role_Manager)]
     public class ProductController : Controller
     {
         /// <summary>

--- a/TeaTimeApplication/Areas/Admin/Controllers/StoreController.cs
+++ b/TeaTimeApplication/Areas/Admin/Controllers/StoreController.cs
@@ -10,7 +10,7 @@ namespace TeaTimeApplication.Areas.Admin.Controllers
     /// 產品 Controller
     /// </summary>
     [Area("Admin")]
-    [Authorize(Roles = SD.Role_Admin)]
+    [Authorize(Roles = SD.Role_Admin + "," + SD.Role_Manager)]
     public class StoreController : Controller
     {
         /// <summary>

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml
@@ -4,7 +4,14 @@
     ViewData["Title"] = "Register";
 }
 
-<h1>@ViewData["Title"]</h1>
+@if (User.IsInRole(SD.Role_Admin) || User.IsInRole(SD.Role_Manager))
+{
+    <h1 class="pt-4">註冊管理者帳號</h1>
+}
+else
+{
+    <h1>@ViewData["Title"]</h1>
+}
 
 <div class="row">
     <div class="col-md-4">
@@ -42,18 +49,22 @@
                 <label asp-for="Input.Address">Address</label>
                 <span asp-validation-for="Input.Address" class="text-danger"></span>
             </div>
-            @*角色列表選單*@
-            <div class="form-floating mb-3">
-                <select asp-for="Input.Role" asp-items="@Model.Input.RoleList" class="form-select">
-                    <option disabled selected>-Select Role-</option>
-                </select>
-            </div>
-            @*店鋪列表選單*@
-            <div class="form-floating mb-3">
-                <select asp-for="Input.StoreId" style="display:none" asp-items="@Model.Input.StoreList" class="form-select">
-                    <option disabled selected>-Select Store-</option>
-                </select>
-            </div>
+            @*後台管理者或經理註冊帳號時，才顯示角色與店鋪選單*@
+            @if (User.IsInRole(SD.Role_Admin) || User.IsInRole(SD.Role_Manager))
+            {
+                @*角色列表選單*@
+                <div class="form-floating mb-3">
+                    <select asp-for="Input.Role" asp-items="@Model.Input.RoleList" class="form-select">
+                        <option disabled selected>-Select Role-</option>
+                    </select>
+                </div>
+                @*店鋪列表選單*@
+                <div class="form-floating mb-3">
+                    <select asp-for="Input.StoreId" style="display:none" asp-items="@Model.Input.StoreList" class="form-select">
+                        <option disabled selected>-Select Store-</option>
+                    </select>
+                </div>
+            }
             <button id="registerSubmit" type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
         </form>
     </div>

--- a/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/TeaTimeApplication/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -213,7 +213,15 @@ namespace TeaTimeApplication.Areas.Identity.Pages.Account
                     }
                     else
                     {
-                        await _signInManager.SignInAsync(user, isPersistent: false);
+                        if (User.IsInRole(SD.Role_Admin) || User.IsInRole(SD.Role_Manager))
+                        {
+                            TempData["success"] = "建立使用者成功";
+                        }
+                        else 
+                        {
+                            await _signInManager.SignInAsync(user, isPersistent: false);
+                        }
+
                         return LocalRedirect(returnUrl);
                     }
                 }

--- a/TeaTimeApplication/Program.cs
+++ b/TeaTimeApplication/Program.cs
@@ -11,6 +11,13 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddControllersWithViews();
 
+// Load local User Secrets before reading configuration values, then re-apply
+// environment and command-line providers so Azure App Service settings win.
+builder.Configuration
+    .AddUserSecrets<Program>(optional: true)
+    .AddEnvironmentVariables()
+    .AddCommandLine(args);
+
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
 // 註冊 DbContext
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
@@ -34,11 +41,6 @@ builder.Services.AddScoped<IDbInitializer, DbInitializer>();
 // 註冊使用 Razor 服務
 builder.Services.AddRazorPages();
 
-// .Net User Secrets 在開發環境使用
-if (builder.Environment.IsDevelopment())
-{
-    builder.Configuration.AddUserSecrets<Program>();
-}
 // 註冊 IUnitOfWork,UnitOfWork DI 服務
 builder.Services.AddScoped<IUnitOfWork,UnitOfWork>();
 

--- a/TeaTimeApplication/Program.cs
+++ b/TeaTimeApplication/Program.cs
@@ -4,6 +4,7 @@ using TeaTime.DataAccess.UnitOfWork;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using TeaTime.Utility;
+using TeaTime.DataAccess.DBInitializer;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -26,6 +27,9 @@ builder.Services.ConfigureApplicationCookie(options =>
     options.LogoutPath = $"/Identity/Account/Logout";
     options.AccessDeniedPath = $"/Identity/Account/AccessDenied";
 });
+
+// 註冊資料庫初始化器，供啟動流程套用 migration 並建立預設身分資料。
+builder.Services.AddScoped<IDbInitializer, DbInitializer>();
 
 // 註冊使用 Razor 服務
 builder.Services.AddRazorPages();
@@ -56,6 +60,9 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+// 在啟用驗證與授權前初始化資料庫、角色與預設管理者帳號。
+SeedDatabase();
+
 // 增加身分驗證
 app.UseAuthentication();
 // 授權
@@ -69,3 +76,16 @@ app.MapControllerRoute(
     pattern: "{area=Customer}/{controller=Home}/{action=Index}/{id?}");
 
 app.Run();
+
+/// <summary>
+/// 建立服務範圍並執行資料庫初始化流程，確保 migration、預設角色與管理者帳號在應用程式啟動時完成設定。
+/// </summary>
+void SeedDatabase() 
+{
+    using (var scope = app.Services.CreateScope()) 
+    {
+        // 透過獨立 scope 解析 scoped service，避免直接從 root provider 取得資料庫相關服務。
+        var dbInitializer = scope.ServiceProvider.GetRequiredService<IDbInitializer>();
+        dbInitializer.Initialize();
+    }
+}

--- a/TeaTimeApplication/Views/Shared/_Layout.cshtml
+++ b/TeaTimeApplication/Views/Shared/_Layout.cshtml
@@ -29,8 +29,8 @@
                             <a class="nav-link text-dark" asp-area="Admin" asp-controller="Order" asp-action="Index">訂單管理</a>
                         </li>
 
-                        @*新增判斷登入角色為 admin 才會看到 [內容管理]*@
-                        @if (User.IsInRole(SD.Role_Admin))
+                        @*後台管理者或經理登入時，才顯示內容管理選單*@
+                        @if (User.IsInRole(SD.Role_Admin) || User.IsInRole(SD.Role_Manager))
                         {
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle text-dark" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" area-expanded="false">
@@ -47,6 +47,7 @@
                                         分店
                                     </a>
                                     <div class="dropdown-divider"></div>
+                                    <a class="dropdown-item" asp-area="Identity" asp-page="/Account/Register">建立使用者</a>
                                 </div>
                             </li>
                         }

--- a/TeaTimeApplication/appsettings.Development.json
+++ b/TeaTimeApplication/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=TeaTimeTest;Trusted_Connection=True;TrustServerCertificate=True"
   }
 }

--- a/TeaTimeApplication/appsettings.Production.example.json
+++ b/TeaTimeApplication/appsettings.Production.example.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  }
+}
+


### PR DESCRIPTION
## Summary
此 PR 調整後台權限、使用者建立流程、資料庫初始化流程，以及部署環境的連線字串設定方式。
後台內容管理由原本僅 Admin 可使用，擴充為 Admin 與 Manager 皆可使用。應用程式啟動時會套用資料庫 migration、建立預設角色與管理者帳號，並調整本機與 Azure App Service 的機密設定覆蓋順序。

## Changes
- 新增 DbInitializer 與 IDbInitializer，在應用程式啟動時執行 migration、建立預設角色與預設管理者帳號
- 新增 TeaTime.DataAccess 對 TeaTime.Utility 的專案參考，以使用角色常數
- 修改 Category、Product、Store 後台 Controller 權限，允許 Admin 與 Manager 存取
- 修改註冊頁面，讓 Admin 或 Manager 建立使用者時顯示角色與店鋪選單
- 修改註冊成功後的行為，後台建立使用者時不自動登入新帳號，改以成功訊息回饋
- 修改共用版面導覽列，讓 Admin 與 Manager 可看到內容管理選單，並新增建立使用者入口
- 調整 Program.cs，提前載入 User Secrets，並重新套用環境變數與命令列設定，確保 Azure App Service 設定可覆蓋本機 secrets
- 修改 Program.cs，註冊並執行資料庫初始化流程
- 調整 .gitignore，忽略實際的 appsettings.Production.json
- 新增 appsettings.Production.example.json 作為可進版控的 Production 設定範本
- 在 appsettings.Development.json 補上本機開發用資料庫連線字串