### PR TITLE
fix(ci): 指定 Azure 部署 workflow 的 Web 專案路徑

### DIFF
--- a/.github/workflows/main_teatimedemo.yml
+++ b/.github/workflows/main_teatimedemo.yml
@@ -24,10 +24,10 @@ jobs:
           dotnet-version: '8.x'
 
       - name: Build with dotnet
-        run: dotnet build --configuration Release
+        run: dotnet build TeaTimeApplication/TeaTimeApplication.csproj --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish TeaTimeApplication/TeaTimeApplication.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
@@ -47,7 +47,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: .net-app
-      
+
       - name: Login to Azure
         uses: azure/login@v2
         with:
@@ -62,4 +62,3 @@ jobs:
           app-name: 'TeaTimeDemo'
           slot-name: 'Production'
           package: .
-          


### PR DESCRIPTION
## Summary
此 PR 修正 Azure App Service 的 GitHub Actions 部署流程，避免 workflow 在 repository 根目錄執行 dotnet build / dotnet publish 時找不到專案或方案檔。部署流程現在會明確指定 TeaTimeApplication/TeaTimeApplication.csproj 作為 build 與 publish 目標，讓 Web 應用程式能正確產生部署 artifact。

## Changes
- 修改 Azure App Service 部署 workflow 的 dotnet build 指令，改為指定 TeaTimeApplication/TeaTimeApplication.csproj
- 修改 Azure App Service 部署 workflow 的 dotnet publish 指令，改為指定 TeaTimeApplication/TeaTimeApplication.csproj
- 調整 workflow 檔案的換行與檔尾格式
- 測試結果尚未從目前上下文確認